### PR TITLE
Add package.json for UPM

### DIFF
--- a/FishNet/Plugins/Bayou/package.json
+++ b/FishNet/Plugins/Bayou/package.json
@@ -1,0 +1,26 @@
+{
+    "name": "com.firstgeargames.fishnet.bayou",
+    "version": "4.1.0",
+    "displayName": "Bayou",
+    "description": "A WebGL transport for Fish-Networking.",
+    "unity": "2021.3",
+    "documentationUrl": "https://fish-networking.gitbook.io/docs/",
+    "licensesUrl": "https://github.com/FirstGearGames/Bayou/blob/main/LICENSE",
+    "license": "MIT",
+    "keywords": [
+      "FishNetworking",
+      "Networking",
+      "FishNet",
+      "Unity Networking",
+      "WebGL",
+      "Transport",
+      "WebSocket"
+    ],
+    "author": {
+      "name": "FirstGearGames",
+      "url": "http://www.firstgeargames.com"
+    },
+    "dependencies": {
+      "com.firstgeargames.fishnet": "4.1.0"
+    }
+}

--- a/FishNet/Plugins/Bayou/package.json.meta
+++ b/FishNet/Plugins/Bayou/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4a34a4248fc239244bf4b330d8c539e7
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Add package.json to allow package import via UPM in Unity.

After merging this PR, you can import via UPM by following these steps
1. Open the Unity package manager
2. Press "Add package from git URL..."
3. Enter the following URL
https://github.com/FirstGearGames/Bayou.git?path=FishNet/Plugins/Bayou

### Motivation
I use git to manage my Unity project.
I want to use Bayou without uploading your code on my repository.