### PR TITLE
Ngrok websocket server fix

### DIFF
--- a/FishNet/Plugins/Bayou/SimpleWebTransport/Server/ServerHandshake.cs
+++ b/FishNet/Plugins/Bayou/SimpleWebTransport/Server/ServerHandshake.cs
@@ -110,9 +110,13 @@ namespace JamesFrowen.SimpleWeb
         }
 
 
-        static void GetKey(string msg, byte[] keyBuffer)
+       static void GetKey(string msg, byte[] keyBuffer)
         {
-            var KeyIndex = msg.IndexOf(KeyHeaderString);
+            //  really should be parsing http headers properly here, and then finding required header,
+            //  as this string could be crammed in anywhere in the message
+            //  but as a hack, for https://github.com/FirstGearGames/Bayou/issues/12
+            //  search for the key case insensitively 
+            var KeyIndex = msg.IndexOf(KeyHeaderString,StringComparison.InvariantCultureIgnoreCase);
             if ( KeyIndex <= -1 )
                 throw new Exception($"Request missing required header {KeyHeaderString}");
                 

--- a/FishNet/Plugins/Bayou/SimpleWebTransport/Server/ServerHandshake.cs
+++ b/FishNet/Plugins/Bayou/SimpleWebTransport/Server/ServerHandshake.cs
@@ -112,7 +112,11 @@ namespace JamesFrowen.SimpleWeb
 
         static void GetKey(string msg, byte[] keyBuffer)
         {
-            int start = msg.IndexOf(KeyHeaderString) + KeyHeaderString.Length;
+            var KeyIndex = msg.IndexOf(KeyHeaderString);
+            if ( KeyIndex <= -1 )
+                throw new Exception($"Request missing required header {KeyHeaderString}");
+                
+            int start = KeyIndex + KeyHeaderString.Length;
 
             Log.Verbose($"Handshake Key: {msg.Substring(start, KeyLength)}");
             Encoding.ASCII.GetBytes(msg, start, KeyLength, keyBuffer, 0);


### PR DESCRIPTION
https://github.com/FirstGearGames/Bayou/issues/12

This is a fix for SimpleWebTransport attempting to read the websocket handshake key `"Sec-WebSocket-Key: "` from the response headers, but
- Some servers respond with different case (typically. `Sec-Websocket-Key` instead of `Sec-WebSocket-Key`). 
  - Specfifically in our case, Ngrok sends `Websocket`
  -`gr: I can't remember off hand which is the correct case, but that's a little irrelevent when established servers & clients send the wrong things` 
- The code previously didn't actually check if this _required_ header was missing, and thus would read the key from `-1 + offset`, which is obviously wrong. (could read out of bounds & throw, could just read garbage)
  - As it's a requirement, I made it throw.