### PR TITLE
Disable Nagles Algorithm

### DIFF
--- a/FishNet/Plugins/Bayou/SimpleWebTransport/Server/WebSocketServer.cs
+++ b/FishNet/Plugins/Bayou/SimpleWebTransport/Server/WebSocketServer.cs
@@ -105,6 +105,10 @@ namespace JamesFrowen.SimpleWeb
                     while (true)
                     {
                         TcpClient client = listener.AcceptTcpClient();
+                        // Disables Nagles Algorithm, which is turned on for TCP/IP clients by default (RFC 896).
+                        // Nagle's Algorithm causes small packets to be cached and sent together until an acknowledgment (ACK)
+                        // is received for a previously sent packet. This almost certainly introduces latency in the game.
+                        client.NoDelay = true;
                         tcpConfig.ApplyTo(client);
 
 


### PR DESCRIPTION
Packets can get stuck waiting for an acknowledgment from in-flight packets when Nagle's Algorithm is enabled (which is the default behavior for TCP clients). By disabling Nagle's Algorithm, I observed a significant reduction in latency for my messages sent. I went from an average of 112ms to 72ms from client --> server --> observers. Packets get stuck when Nagle's Algorithm is enabled. This is actually quite a common issue/complaint amongst people who develop TCP applications. 

https://brooker.co.za/blog/2024/05/09/nagle.html
https://news.ycombinator.com/item?id=25194988