### PR TITLE
Fixed two bugs in SimpleWeb and upgraded client timeout pinging

### DIFF
--- a/FishNet/Plugins/Bayou/SimpleWebTransport/Client/Webgl/plugin/SimpleWeb.jslib
+++ b/FishNet/Plugins/Bayou/SimpleWebTransport/Client/Webgl/plugin/SimpleWeb.jslib
@@ -1,64 +1,74 @@
+
 // this will create a global object
 const SimpleWeb = {
     webSockets: [],
     next: 1,
+    pingWorkers: {},
+
     GetWebSocket: function (index) {
-        return SimpleWeb.webSockets[index]
+        return SimpleWeb.webSockets[index];
     },
+
     AddNextSocket: function (webSocket) {
         var index = SimpleWeb.next;
         SimpleWeb.next++;
         SimpleWeb.webSockets[index] = webSocket;
         return index;
     },
+
     RemoveSocket: function (index) {
         SimpleWeb.webSockets[index] = undefined;
     },
-	
-    setupPinging: function(index) {
-        const sendPing = function() {
-            var webSocket = SimpleWeb.GetWebSocket(index);
-            if (webSocket && webSocket.readyState === WebSocket.OPEN) {
-                // Create a binary ping message
-                var buffer = new ArrayBuffer(5); // 1 byte for PacketId + 4 bytes for timestamp
-                var view = new DataView(buffer);
-                view.setUint8(0, 14); // 14 is the PacketId for PingPong
-                view.setUint32(1, Math.floor(Date.now() / 1000), true);
-                webSocket.send(buffer);
-            } else {
-                SimpleWeb.stopPinging(index);
+
+    setupPinging: function (index) {
+        // Create a worker dynamically from a Blob
+        const workerCode = `
+            self.onmessage = function(e) {
+                const { interval } = e.data;
+                setInterval(() => {
+                    self.postMessage("ping");
+                }, interval);
+            };
+        `;
+        const blob = new Blob([workerCode], { type: "application/javascript" });
+        const worker = new Worker(URL.createObjectURL(blob));
+
+        worker.onmessage = function (e) {
+            if (e.data === "ping") {
+                var webSocket = SimpleWeb.GetWebSocket(index);
+                if (webSocket && webSocket.readyState === WebSocket.OPEN) {
+                    // Create a binary ping message
+                    var buffer = new ArrayBuffer(5); // 1 byte for PacketId + 4 bytes for timestamp
+                    var view = new DataView(buffer);
+                    view.setUint8(0, 14); // 14 is the PacketId for PingPong
+                    view.setUint32(1, Math.floor(Date.now() / 1000), true);
+                    webSocket.send(buffer);
+                } else {
+                    SimpleWeb.stopPinging(index);
+                }
             }
         };
 
-        document.addEventListener("visibilitychange", function() {
-            if (document.hidden) {
-                if (!SimpleWeb.pingIntervals[index]) {
-                    SimpleWeb.pingIntervals[index] = setInterval(sendPing, 10000); // Every 10 seconds when hidden
-                }
-            } else {
-                SimpleWeb.stopPinging(index);
-            }
-        });
+        // Start the worker with a 10s interval
+        worker.postMessage({ interval: 10000 });
 
-        // Start pinging immediately if the tab is already hidden
-        if (document.hidden) {
-            SimpleWeb.pingIntervals[index] = setInterval(sendPing, 10000);
-        }
+        // Store worker reference
+        SimpleWeb.pingWorkers[index] = worker;
     },
-    stopPinging: function(index) {
-        if (SimpleWeb.pingIntervals[index]) {
-            clearInterval(SimpleWeb.pingIntervals[index]);
-            delete SimpleWeb.pingIntervals[index];
+
+    stopPinging: function (index) {
+        if (SimpleWeb.pingWorkers[index]) {
+            SimpleWeb.pingWorkers[index].terminate();
+            delete SimpleWeb.pingWorkers[index];
         }
-    }	
+    }
 };
 
 function IsConnected(index) {
     var webSocket = SimpleWeb.GetWebSocket(index);
     if (webSocket) {
         return webSocket.readyState === webSocket.OPEN;
-    }
-    else {
+    } else {
         return false;
     }
 }
@@ -68,29 +78,24 @@ function Connect(addressPtr, openCallbackPtr, closeCallBackPtr, messageCallbackP
     console.log("Connecting to " + address);
     // Create webSocket connection.
     var webSocket = new WebSocket(address);
-    webSocket.binaryType = 'arraybuffer';
+    webSocket.binaryType = "arraybuffer";
     const index = SimpleWeb.AddNextSocket(webSocket);
 
-	SimpleWeb.setupPinging(index);
-
-    // Connection opened
     webSocket.onopen = function (event) {
         console.log("Connected to " + address);
-        dynCall('vi', openCallbackPtr, [index]);
-    }
+        SimpleWeb.setupPinging(index);
+        dynCall("vi", openCallbackPtr, [index]);
+    };
+
     webSocket.onclose = function (event) {
         console.log("Disconnected from " + address);
-        dynCall('vi', closeCallBackPtr, [index]);
-    }
-	
-	SimpleWeb.stopPinging(index);
-        Runtime.dynCall('vi', closeCallBackPtr, [index]);
-    });	
+        SimpleWeb.stopPinging(index);
+        dynCall("vi", closeCallBackPtr, [index]);
+    };
 
     // Listen for messages
     webSocket.onmessage = function (event) {
         if (event.data instanceof ArrayBuffer) {
-            // TODO dont alloc each time
             var array = new Uint8Array(event.data);
             var arrayLength = array.length;
 
@@ -98,19 +103,17 @@ function Connect(addressPtr, openCallbackPtr, closeCallBackPtr, messageCallbackP
             var dataBuffer = new Uint8Array(HEAPU8.buffer, bufferPtr, arrayLength);
             dataBuffer.set(array);
 
-            dynCall('viii', messageCallbackPtr, [index, bufferPtr, arrayLength]);
+            dynCall("viii", messageCallbackPtr, [index, bufferPtr, arrayLength]);
             _free(bufferPtr);
+        } else {
+            console.error("message type not supported");
         }
-        else {
-            console.error("message type not supported")
-        }
-    }
+    };
 
     webSocket.onerror = function (event) {
-        console.error('Socket Error', event);
-
-        dynCall('vi', errorCallbackPtr, [index]);
-    }
+        console.error("Socket Error", event);
+        dynCall("vi", errorCallbackPtr, [index]);
+    };
 
     return index;
 }
@@ -122,6 +125,7 @@ function Disconnect(index) {
     }
 
     SimpleWeb.RemoveSocket(index);
+    SimpleWeb.stopPinging(index);
 }
 
 function Send(index, arrayPtr, offset, length) {
@@ -136,7 +140,6 @@ function Send(index, arrayPtr, offset, length) {
     return false;
 }
 
-
 const SimpleWebLib = {
     $SimpleWeb: SimpleWeb,
     IsConnected,
@@ -144,5 +147,5 @@ const SimpleWebLib = {
     Disconnect,
     Send
 };
-autoAddDeps(SimpleWebLib, '$SimpleWeb');
+autoAddDeps(SimpleWebLib, "$SimpleWeb");
 mergeInto(LibraryManager.library, SimpleWebLib);

--- a/FishNet/Plugins/Bayou/SimpleWebTransport/Common/Connection.cs
+++ b/FishNet/Plugins/Bayou/SimpleWebTransport/Common/Connection.cs
@@ -116,10 +116,10 @@ namespace JamesFrowen.SimpleWeb
         {
             if (request.Headers.TryGetValue("X-Forwarded-For", out string forwardFor))
             {
-                string actualClientIP = forwardFor.ToString().Split(',').First();
-                // Remove the port number from the address
-                address = actualClientIP.Split(':').First();
-                port = int.Parse(actualClientIP.Split(':').Last());
+                string actualClientIP = forwardFor.Split(',').First().Trim();
+                address = actualClientIP;
+                IPEndPoint ipEndPoint = (IPEndPoint)client.Client.RemoteEndPoint;
+                port = ipEndPoint.Port;
             }
             else
             {


### PR DESCRIPTION
The first bug is inside SimpleWeb.jslib where a hanging }); prevented unity from building.

The second bug is inside Connection.cs where if the client had X-Forwarded-For in their headers the server attempted to int.Parse the port but failed. X-Forwarded-For headers contain IP addresses but not port numbers. https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For

The SimpleWeb.jslib file was updated to use a Web Worker instead of setInterval for a more robust background-thread safe way of pinging the server and keeping the socket connection alive.
Web workers have been supported by all major browsers for quite awhile now and should work within Iframe unity instances too.
https://caniuse.com/webworkers